### PR TITLE
Feature/aws

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,3 +85,5 @@ end
 gem "net-smtp"
 gem "net-pop"
 gem "net-imap"
+
+gem "aws-sdk-s3", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,22 @@ GEM
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    aws-eventstream (1.3.0)
+    aws-partitions (1.877.0)
+    aws-sdk-core (3.190.1)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.8)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.75.0)
+      aws-sdk-core (~> 3, >= 3.188.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.142.0)
+      aws-sdk-core (~> 3, >= 3.189.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.8)
+    aws-sigv4 (1.8.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.20)
     bindex (0.8.1)
     bootsnap (1.17.0)
@@ -109,6 +125,7 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jmespath (1.6.2)
     json (2.7.0)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
@@ -318,6 +335,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  aws-sdk-s3
   bootsnap (>= 1.4.4)
   byebug
   capybara (>= 3.26)

--- a/app/components/artwork/image_component.html.erb
+++ b/app/components/artwork/image_component.html.erb
@@ -1,1 +1,1 @@
-<%= image_tag artwork.image, loading: "lazy", **image_attributes %>
+<%= image_tag artwork.get_image, loading: "lazy", **image_attributes %>

--- a/app/components/shared/form/file_input_component.html.erb
+++ b/app/components/shared/form/file_input_component.html.erb
@@ -7,7 +7,7 @@
   ) %>
   <figure id="file-figure" class="mt-4 flex justify-center items-center">
     <div id="file-preview" class="max-w-[10rem]">
-      <%= image_tag @image if @image&.attached? %>
+      <%= image_tag @image if @image&.present? %>
     </div>
   </figure>
 </div>

--- a/app/components/user/avatar_component.html.erb
+++ b/app/components/user/avatar_component.html.erb
@@ -1,1 +1,1 @@
-<%= image_tag user.get_profile_image, loading: "lazy", **image_attributes %>
+<%= image_tag image_src, loading: "lazy", **image_attributes %>

--- a/app/components/user/avatar_component.rb
+++ b/app/components/user/avatar_component.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class User::AvatarComponent < ViewComponent::Base
-  attr_reader :user
-
   def initialize(user:, size:)
     @user = user
     @size = size
+  end
+
+  def image_src
+    image = @user.get_profile_image
+    image || "default-user-icon.jpeg"
   end
 
   def image_attributes

--- a/app/models/artwork.rb
+++ b/app/models/artwork.rb
@@ -4,7 +4,8 @@ class Artwork < ApplicationRecord
 
   belongs_to :user
 
-  has_one_attached :image
+  # 保存先のサービスをここで指定する。
+  has_one_attached :image, service: :amazon_artwork_images
 
   has_one :artwork_canvas, dependent: :destroy
   accepts_nested_attributes_for :artwork_canvas
@@ -35,6 +36,10 @@ class Artwork < ApplicationRecord
     artworks
   }
 
+
+  def get_image
+    "https://pixeleria-public-images.s3-ap-northeast-1.amazonaws.com/#{image.key}"
+  end
 
   def liked_by?(user)
     likes.any? { |like| like.user_id == user.id }

--- a/app/models/artwork.rb
+++ b/app/models/artwork.rb
@@ -38,7 +38,8 @@ class Artwork < ApplicationRecord
 
 
   def get_image
-    "https://pixeleria-public-images.s3-ap-northeast-1.amazonaws.com/#{image.key}"
+    # "https://pixeleria-public-images.s3-ap-northeast-1.amazonaws.com/#{image.key}"
+    "https://d39xcen2r68k3d.cloudfront.net/#{image.key}"
   end
 
   def liked_by?(user)

--- a/app/models/artwork.rb
+++ b/app/models/artwork.rb
@@ -38,7 +38,6 @@ class Artwork < ApplicationRecord
 
 
   def get_image
-    # "https://pixeleria-public-images.s3-ap-northeast-1.amazonaws.com/#{image.key}"
     "https://d39xcen2r68k3d.cloudfront.net/#{image.key}"
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,7 +62,7 @@ class User < ApplicationRecord
 
   def get_profile_image
     if profile_image.attached?
-      "https://pixeleria-public-images.s3-ap-northeast-1.amazonaws.com/#{profile_image.key}-thumbnail.#{profile_image.content_type.split('/').pop}"
+      "https://d39xcen2r68k3d.cloudfront.net/profile/#{profile_image.key}.webp"
     else
       nil
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,8 @@ class User < ApplicationRecord
     suspended: 2
   }
 
-  has_one_attached :profile_image
+  # 保存先のサービスをここで指定する。
+  has_one_attached :profile_image, service: :amazon_profile_images
 
   has_many :artworks,       dependent: :destroy
   has_many :likes,          dependent: :destroy
@@ -60,7 +61,11 @@ class User < ApplicationRecord
   end
 
   def get_profile_image
-    (profile_image.attached?) ? profile_image : "default-user-icon.jpeg"
+    if profile_image.attached?
+      "https://pixeleria-public-images.s3-ap-northeast-1.amazonaws.com/#{profile_image.key}-thumbnail.#{profile_image.content_type.split('/').pop}"
+    else
+      nil
+    end
   end
 
   def follow(user)

--- a/app/views/public/users/edit.html.erb
+++ b/app/views/public/users/edit.html.erb
@@ -6,7 +6,7 @@
       <div class="grid gap-y-4">
         <div>
           <%= component "shared/form/label", form: f, field: :profile_image %>
-          <%= component "shared/form/file_input", form: f, field_name: :profile_image, image: @user.profile_image %>
+          <%= component "shared/form/file_input", form: f, field_name: :profile_image, image: @user.get_profile_image %>
         </div>
 
         <div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,7 +31,8 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  # モデルごとに保存バケットを分けるため、ここではサービスを指定しない。
+  # config.active_storage.service = :amazon
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,8 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  # モデルごとに保存バケットを分けるため、ここではサービスを指定しない。
+  # config.active_storage.service = :amazon
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,13 +6,20 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
-# Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-# amazon:
-#   service: S3
-#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-#   region: us-east-1
-#   bucket: your_own_bucket
+# プロフィール画像とドット絵の保存バケットを分ける
+amazon: &amazon
+  service: S3
+  access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
+  secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
+  region: <%= ENV["AWS_REGION"] %>
+
+amazon_profile_images:
+  <<: *amazon
+  bucket: <%= ENV["AWS_S3_BUCKET_NAME_ORIGINAL"] %>
+
+amazon_artwork_images:
+  <<: *amazon
+  bucket: <%= ENV["AWS_S3_BUCKET_NAME_PUBLIC"] %>
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
- ユーザープロフィール画像とドット絵の画像をS3に保存するようにしました。
- それぞれの保存先は、異なるS3バケットにしました。
- ユーザープロフィール画像は、Lambda側で **サイズは256x256、フォーマットはWebP** に変換されます。
- S3に保存した画像をCloudFront経由で配信するようにしました。
- 実装に伴い、コンポーネントのロジック修正を実施しました。